### PR TITLE
Feature: 로그인 여부에 따르 헤더 구현

### DIFF
--- a/epigram/package-lock.json
+++ b/epigram/package-lock.json
@@ -13,7 +13,8 @@
         "next": "15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.54.2"
+        "react-hook-form": "^7.54.2",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -649,7 +650,7 @@
       "version": "19.0.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.1.tgz",
       "integrity": "sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -945,7 +946,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2405,6 +2406,34 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/epigram/package.json
+++ b/epigram/package.json
@@ -14,7 +14,8 @@
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.54.2"
+    "react-hook-form": "^7.54.2",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/epigram/src/components/landing/KeyVisual.tsx
+++ b/epigram/src/components/landing/KeyVisual.tsx
@@ -1,7 +1,10 @@
+import { useAuth } from '@/lib/context/AuthContext';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export default function KeyVisual() {
+  const { loginState } = useAuth();
+
   return (
     <div
       className="relative flex h-[calc(100vh-80px)] w-full flex-col items-center justify-center gap-10 bg-cover bg-center bg-repeat-x text-center"
@@ -18,8 +21,8 @@ export default function KeyVisual() {
       </span>
 
       <Link
-        href="/"
-        className="bg-black-500 flex h-16 w-72 items-center justify-center rounded-xl text-xl font-semibold text-white"
+        href={loginState ? '/main' : '/'}
+        className="flex h-16 w-72 items-center justify-center rounded-xl bg-black-500 text-xl font-semibold text-white"
       >
         시작하기
       </Link>

--- a/epigram/src/components/landing/LandingLast.tsx
+++ b/epigram/src/components/landing/LandingLast.tsx
@@ -1,7 +1,10 @@
+import { useAuth } from '@/lib/context/AuthContext';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export default function LandingLast() {
+  const { loginState } = useAuth();
+
   return (
     <div
       className="relative flex h-screen w-full flex-col items-center justify-center bg-cover bg-center bg-repeat-x"
@@ -16,7 +19,7 @@ export default function LandingLast() {
         />
       </h2>
       <Link
-        href="/"
+        href={loginState ? '/main' : '/'}
         className="flex h-16 w-72 items-center justify-center rounded-xl bg-black-500 text-xl font-semibold text-white"
       >
         시작하기

--- a/epigram/src/components/share/NavBar.tsx
+++ b/epigram/src/components/share/NavBar.tsx
@@ -1,37 +1,83 @@
+import { useAuth } from '@/lib/context/AuthContext';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export default function NavBar() {
+  const { loginState, user } = useAuth();
+
   return (
     <header className="border-b-[1px] border-[#D7D7D7] px-5">
-      <div className="mx-auto flex h-[80px] w-full max-w-[1680px] items-center justify-between">
-        <Link href="/search">
-          <Image
-            src="/icons/search-icon.svg"
-            width={36}
-            height={36}
-            alt="검색 아이콘"
-          />
-        </Link>
-        <h1>
-          <Link href="/">
+      {loginState ? (
+        <div className="mx-auto flex h-[80px] w-full max-w-[1680px] items-center justify-between gap-5">
+          <div className="flex items-center gap-8">
+            <h1>
+              <Link href={loginState ? 'main' : '/'}>
+                <Image
+                  src="/images/logo.png"
+                  width={131}
+                  height={36}
+                  alt="epigram 로고"
+                />
+              </Link>
+            </h1>
+            <div className="flex items-center gap-6">
+              <Link
+                href="/feed"
+                className="text-base font-semibold text-black-600"
+              >
+                피드
+              </Link>
+              <Link
+                href="/search"
+                className="text-base font-semibold text-black-600"
+              >
+                검색
+              </Link>
+            </div>
+          </div>
+          <div>
+            <Link
+              href="/myPage"
+              className="flex items-center gap-2 text-base font-medium text-gray-300"
+            >
+              <Image
+                src={user?.image || '/images/profile-default.png'}
+                width={24}
+                height={24}
+                alt="프로필 이미지"
+              />
+              {user?.nickname}
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="mx-auto flex h-[80px] w-full max-w-[1680px] items-center justify-between">
+          <Link href="/search">
             <Image
-              src="/images/logo.png"
-              width={172}
-              height={48}
-              alt="epigram 로고"
+              src="/icons/search-icon.svg"
+              width={36}
+              height={36}
+              alt="검색 아이콘"
             />
           </Link>
-        </h1>
-        <Link href="/myPage">
-          <Image
-            src="/icons/profile-icon.svg"
-            width={36}
-            height={36}
-            alt="프로필 아이콘"
-          />
-        </Link>
-      </div>
+          <h1>
+            <Link href="/">
+              <Image
+                src="/images/logo.png"
+                width={172}
+                height={48}
+                alt="epigram 로고"
+              />
+            </Link>
+          </h1>
+          <Link
+            href="/login"
+            className="flex h-10 w-28 items-center justify-center rounded-lg bg-gray-100 transition-all hover:bg-gray-200"
+          >
+            로그인
+          </Link>
+        </div>
+      )}
     </header>
   );
 }

--- a/epigram/src/lib/context/AuthContext.tsx
+++ b/epigram/src/lib/context/AuthContext.tsx
@@ -1,0 +1,59 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { UserInfoType } from '../types/type';
+
+type AuthContextType = {
+  loginState: boolean;
+  user: UserInfoType | null;
+  login: (data: any) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [loginState, setLoginState] = useState<boolean>(false);
+  const [user, setUser] = useState<UserInfoType | null>(null);
+
+  useEffect(() => {
+    const storageUserInfo = localStorage.getItem('userInfo');
+    const storageAccessToken = localStorage.getItem('accessToken');
+
+    if (storageUserInfo && storageAccessToken) {
+      setLoginState(true);
+      setUser(JSON.parse(storageUserInfo));
+    }
+  }, []);
+
+  const login = (data: any) => {
+    setLoginState(true);
+    setUser(data.user);
+
+    localStorage.setItem('userInfo', JSON.stringify(data.user));
+    localStorage.setItem('accessToken', data.accessToken);
+  };
+
+  const logout = () => {
+    setLoginState(false);
+    setUser(null);
+
+    localStorage.removeItem('userInfo');
+    localStorage.removeItem('accessToken');
+  };
+
+  return (
+    <AuthContext.Provider value={{ loginState, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): any => {
+  const context = useContext(AuthContext);
+  return context;
+};

--- a/epigram/src/lib/hooks/LoggedInRedirect.ts
+++ b/epigram/src/lib/hooks/LoggedInRedirect.ts
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export const LoggedInReDirect = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const storageUserInfo = localStorage.getItem('userInfo');
+    const storageAccessToken = localStorage.getItem('accessToken');
+
+    if (storageUserInfo && storageAccessToken) {
+      alert('로그아웃후에 진행해주세요.');
+      router.push('/main');
+    }
+  }, []);
+};

--- a/epigram/src/lib/types/type.ts
+++ b/epigram/src/lib/types/type.ts
@@ -11,3 +11,14 @@ export interface LoginType {
   email: string;
   password: string;
 }
+
+// 유저 정보 타입
+export interface UserInfoType {
+  email: string;
+  nickname: string;
+  createdAt: string;
+  id: number;
+  teamId: string;
+  updatedAt: string;
+  image: string | null;
+}

--- a/epigram/src/pages/_app.tsx
+++ b/epigram/src/pages/_app.tsx
@@ -1,12 +1,15 @@
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import NavBar from '@/components/share/NavBar';
+import { AuthProvider } from '@/lib/context/AuthContext';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
-      <NavBar />
-      <Component {...pageProps} />
+      <AuthProvider>
+        <NavBar />
+        <Component {...pageProps} />
+      </AuthProvider>
     </>
   );
 }

--- a/epigram/src/pages/login/index.tsx
+++ b/epigram/src/pages/login/index.tsx
@@ -1,4 +1,6 @@
 import { fetchLogin } from '@/lib/apis/api';
+import { useAuth } from '@/lib/context/AuthContext';
+import { LoggedInReDirect } from '@/lib/hooks/LoggedInReDirect';
 import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -6,6 +8,8 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+// Todo - 로그인 페이지 컴포넌트 나누기
+// Todo - 로그인 상태 토스트 메시지로 띄우기
 export default function LoginPage() {
   const [passwordView, setPasswordView] = useState<boolean>(false);
   const LOGIN_INPUT_LIST = [
@@ -52,6 +56,8 @@ export default function LoginPage() {
 
   const router = useRouter();
 
+  const { loginState, login } = useAuth();
+
   const onSubmit = async (data: any) => {
     try {
       // 이메일, 비밀번호 공백 제거
@@ -64,8 +70,7 @@ export default function LoginPage() {
         password: cleanedPassword,
       });
 
-      localStorage.setItem('userInfo', JSON.stringify(res.user));
-      localStorage.setItem('accessToken', res.accessToken);
+      login(res);
       console.log(res);
 
       // 로그인 후 메인 페이지로 이동
@@ -83,6 +88,9 @@ export default function LoginPage() {
       }
     }
   };
+
+  // 로그인이 되어있는 상태로 접근시 메인 페이지로 리다이렉트
+  LoggedInReDirect();
 
   return (
     <div className="flex h-[calc(100vh-80px)] w-full flex-col items-center justify-center bg-background">

--- a/epigram/src/pages/signup/index.tsx
+++ b/epigram/src/pages/signup/index.tsx
@@ -1,10 +1,13 @@
 import { fetchSignUp } from '@/lib/apis/api';
+import { LoggedInReDirect } from '@/lib/hooks/LoggedInReDirect';
 import clsx from 'clsx';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+// Todo - 회원가입 페이지 컴포넌트 나누기
+// Todo - 회원가입 상태 토스트 메시지로 띄우기
 export default function Signup() {
   const [passwordView, setPasswordView] = useState<boolean>(false);
   const [passwordCheckView, setPasswordCheckView] = useState<boolean>(false);
@@ -99,6 +102,10 @@ export default function Signup() {
       console.log('회원가입 도중 에러 발생', error);
     }
   };
+
+  // 로그인이 되어있는 상태로 접근시 메인 페이지로 리다이렉트
+  LoggedInReDirect();
+
   return (
     <div className="flex h-full w-full flex-col items-center justify-center bg-background pb-44 pt-20">
       <h2 className="mb-20">


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 로그인 했을 경우 헤더가 로그인 상태로 변경
- 로그인 했을 경우 기존 페이지가 index에서 main으로 이동 되도록 변경

# 작업 상세 내용
- Context API를 사용하여 로그인 상태를 전역으로 관리
  - 로그인 후에는 로컬스토리지를 확인해서 로그인 정보가 있으면 해당 데이터 적용
- 로그인 후 로그인, 회원가입 페이지 접근시 메인 페이지로 리다이렉트 코드 커스텀 훅으로 작성
- 로그인 후 로고나 특정 버튼 클릭시 index 페이지 -> main 페이지로 경로 수정

https://github.com/user-attachments/assets/cb989eae-2808-4b6e-97ae-5531a27aa106

# 리뷰 요구사항
_집중 리뷰 부분 작성_

# 연관된 이슈 번호
- #15 