### PR TITLE
Feature: 에피그램 피드 api 연동

### DIFF
--- a/epigram/src/components/share/Epigram.tsx
+++ b/epigram/src/components/share/Epigram.tsx
@@ -1,4 +1,5 @@
 import { EpigramType } from '@/lib/types/type';
+import clsx from 'clsx';
 
 interface EpigramProps {
   data?: EpigramType;
@@ -10,7 +11,10 @@ export default function Epigram({ data, height }: EpigramProps) {
     <div className="mx-auto w-full max-w-[640px]">
       <div style={{ marginBottom: height ? '0px' : '56px' }}>
         <div
-          className="mb-2 flex w-full flex-col justify-between gap-5 rounded-2xl bg-cover bg-center bg-repeat-x p-6 shadow-[0_3px_12px_rgba(0,0,0,0.1)]"
+          className={clsx(
+            'mb-2 flex w-full flex-col gap-5 rounded-2xl bg-cover bg-center bg-repeat-x p-6 shadow-[0_3px_12px_rgba(0,0,0,0.1)]',
+            data ? 'justify-between' : 'justify-center'
+          )}
           style={{
             backgroundImage: 'url(/images/back-line.png)',
             height: height && `${height}px`,

--- a/epigram/src/pages/feed/index.tsx
+++ b/epigram/src/pages/feed/index.tsx
@@ -3,6 +3,7 @@ import FixedMenu from '@/components/share/FixedMenu';
 import { fetchNewEpigram } from '@/lib/apis/epigram';
 import { EpigramType } from '@/lib/types/type';
 import { useQuery } from '@tanstack/react-query';
+import Image from 'next/image';
 import Link from 'next/link';
 
 export default function FeedPage() {
@@ -28,13 +29,27 @@ export default function FeedPage() {
         피드
       </h2>
       <div className="mx-auto grid w-full max-w-[1200px] grid-cols-2 gap-x-[30px] gap-y-[40px]">
-        {data.list.map((epigram: EpigramType) => {
-          return (
-            <Link href={`/feed/${epigram.id}`} key={epigram.id}>
-              <Epigram data={epigram} height={260} />
-            </Link>
-          );
-        })}
+        {data.list ? (
+          data.list.map((epigram: EpigramType) => {
+            return (
+              <Link href={`/feed/${epigram.id}`} key={epigram.id}>
+                <Epigram data={epigram} height={260} />
+              </Link>
+            );
+          })
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-2">
+            <Image
+              src="/images/not-content.png"
+              width={144}
+              height={144}
+              alt="컨텐츠 없는 경우 아이콘"
+            />{' '}
+            <p className="text-center text-xl">
+              작성된 에피그램 피드가 없습니다.
+            </p>
+          </div>
+        )}
       </div>
       {data.list.length > 6 && (
         <div className="mt-[72px] flex justify-center">

--- a/epigram/src/pages/feed/index.tsx
+++ b/epigram/src/pages/feed/index.tsx
@@ -1,29 +1,51 @@
 import Epigram from '@/components/share/Epigram';
 import FixedMenu from '@/components/share/FixedMenu';
+import { fetchNewEpigram } from '@/lib/apis/epigram';
+import { EpigramType } from '@/lib/types/type';
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 
 export default function FeedPage() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['newEpigram'],
+    queryFn: async () => {
+      const res = await fetchNewEpigram({ limit: 6, cursor: 0 });
+      return res;
+    },
+  });
+
+  if (isLoading) {
+    return <div>로딩중...</div>;
+  }
+
+  if (isError) {
+    return <div>에러...</div>;
+  }
+
   return (
     <div className="h-full min-h-screen bg-background py-[120px]">
       <h2 className="mx-auto mb-10 w-full max-w-[1200px] text-2xl font-semibold text-black-600">
         피드
       </h2>
       <div className="mx-auto grid w-full max-w-[1200px] grid-cols-2 gap-x-[30px] gap-y-[40px]">
-        <Epigram height={260} />
-        <Epigram height={260} />
-        <Epigram height={260} />
-        <Epigram height={260} />
-        <Epigram height={260} />
-        <Epigram height={260} />
+        {data.list.map((epigram: EpigramType) => {
+          return (
+            <Link href={`/feed/${epigram.id}`} key={epigram.id}>
+              <Epigram data={epigram} height={260} />
+            </Link>
+          );
+        })}
       </div>
-      <div className="mt-[72px] flex justify-center">
-        <Link
-          href="/"
-          className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
-        >
-          + 에피그램 더보기
-        </Link>
-      </div>
+      {data.list.length > 6 && (
+        <div className="mt-[72px] flex justify-center">
+          <Link
+            href="/"
+            className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+          >
+            + 에피그램 더보기
+          </Link>
+        </div>
+      )}
       <FixedMenu />
     </div>
   );


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 에피그램 피드 페이지 api 연동

# 작업 상세 내용
- 에피그램 피드 페이지 데이터 가져와서 리스트 노출
- 에피그램의 갯수가 7개 미만이면 더보기 버튼이 미노출 되도록 구현
- 에피그램 클릭시 해당 에피그램의 id값으로 상세 페이지 이동 하도록 구현
- 에피그램 데이터가 없는경우 안내문구 노출

![localhost_3000_feed](https://github.com/user-attachments/assets/08418d8c-317e-4697-9d70-0eb685a32ab9)

# 리뷰 요구사항

_집중 리뷰 부분 작성_

# 연관된 이슈 번호
- #20 
