### PR TITLE
Feature: 에피그램 피드 상세 페이지 api

### DIFF
--- a/epigram/package-lock.json
+++ b/epigram/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.64.2",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.0.6",
         "next": "15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1111,6 +1112,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.0.6.tgz",
+      "integrity": "sha512-LmrXbXF6Vv5WCNmb+O/zn891VPZrH7XbsZgRLBROw6kFiP+iTK49gxTv2Ur3F0Tbw6+sy9BVtSqnWfMUpH+6nA==",
+      "dependencies": {
+        "motion-dom": "^12.0.0",
+        "motion-utils": "^12.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1368,6 +1395,19 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.0.0.tgz",
+      "integrity": "sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==",
+      "dependencies": {
+        "motion-utils": "^12.0.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.0.0.tgz",
+      "integrity": "sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/epigram/package.json
+++ b/epigram/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^5.64.2",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.0.6",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/epigram/src/components/detail/CommentDetail.tsx
+++ b/epigram/src/components/detail/CommentDetail.tsx
@@ -1,0 +1,84 @@
+import { CommentListType, CommentType } from '@/lib/types/type';
+import Image from 'next/image';
+
+interface CommentDetailProps {
+  data: CommentType;
+  userId: number | null;
+}
+
+export default function CommentDetail({ data, userId }: CommentDetailProps) {
+  return (
+    <div className="relative h-full bg-background py-12">
+      <div
+        className="absolute left-0 top-0 h-[15px] w-full bg-cover bg-center bg-repeat-x"
+        style={{ backgroundImage: 'url(/images/line-top.png)' }}
+      />
+      <div className="mx-auto w-full max-w-[640px]">
+        <h3 className="mb-6 text-xl font-semibold">
+          댓글 ({data?.totalCount})
+        </h3>
+        <div className="mb-10 flex items-start gap-4">
+          <Image
+            src="/images/profile-default.png"
+            className="rounded-full"
+            width={48}
+            height={38}
+            alt="프로필 이미지"
+          />
+          <textarea
+            placeholder="100자 이내로 입력해주세요."
+            className="h-[104px] w-full resize-none rounded-lg border-[1px] border-line-200 bg-background px-4 py-3 focus-visible:outline-black-600"
+            maxLength={100}
+          ></textarea>
+        </div>
+
+        {data?.list.map((comment: CommentListType) => {
+          return (
+            <div
+              key={comment.id}
+              className="flex items-start gap-4 border-t-[1px] border-t-line-200 px-6 py-[35px]"
+            >
+              <div className="h-[48px] w-[48px] flex-shrink-0">
+                <Image
+                  src={
+                    comment.writer.image
+                      ? comment.writer.image
+                      : '/images/profile-default.png'
+                  }
+                  className="h-full w-full rounded-full"
+                  width={48}
+                  height={48}
+                  alt="프로필 이미지"
+                />
+              </div>
+              <div className="w-full">
+                <div className="mb-4 flex items-center justify-between">
+                  <div className="flex items-center gap-2 text-base font-normal text-black-300">
+                    <span>{comment.writer.nickname}</span>
+                    <span>1시간 전</span>
+                  </div>
+                  {comment.writer.id === userId && (
+                    <div className="flex items-center gap-4 text-base font-normal">
+                      <button
+                        type="button"
+                        className="text-black-600 underline"
+                      >
+                        수정
+                      </button>
+                      <button type="button" className="text-red underline">
+                        삭제
+                      </button>
+                    </div>
+                  )}
+                </div>
+                <p className="text-xl font-normal text-black-700">
+                  {comment.content}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/epigram/src/components/detail/EpigramDetail.tsx
+++ b/epigram/src/components/detail/EpigramDetail.tsx
@@ -1,0 +1,98 @@
+import { fetchEpigramDetail } from '@/lib/apis/epigram';
+import { EpigramDetailType, Tag } from '@/lib/types/type';
+import { useQuery } from '@tanstack/react-query';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface EpigramDetailProps {
+  data: EpigramDetailType;
+  isMore: boolean;
+}
+
+export default function EpigramDetail({ data, isMore }: EpigramDetailProps) {
+  const [isDropDown, setIsDropDown] = useState<boolean>(false);
+
+  const handleToggle = () => {
+    setIsDropDown((prev) => !prev);
+  };
+  return (
+    <div
+      className="bg-cover bg-center bg-repeat-x py-10"
+      style={{ backgroundImage: 'url(/images/back-line.png)' }}
+    >
+      <div className="mx-auto w-full max-w-[640px]">
+        <div className="relative mb-8 flex items-center justify-between">
+          <ul className="flex items-center gap-4 text-xl font-normal text-blue-400">
+            {data?.tags.map((tag: Tag) => {
+              return <li key={tag.id}>#{tag.name}</li>;
+            })}
+          </ul>
+          {isMore && (
+            <button type="button" onClick={handleToggle}>
+              <Image
+                src="/icons/more-icon.svg"
+                width={36}
+                height={36}
+                alt="더보기 버튼"
+              />
+            </button>
+          )}
+
+          <AnimatePresence>
+            {isDropDown && (
+              <motion.ul
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.3 }}
+                className="absolute right-0 top-[52px] overflow-hidden rounded-2xl border-[1px] border-blue-300 bg-background text-xl font-normal"
+              >
+                <li className="px-8 py-3">
+                  <button type="button">수정하기</button>
+                </li>
+                <li className="px-8 py-3">
+                  <button type="button">삭제하기</button>
+                </li>
+              </motion.ul>
+            )}
+          </AnimatePresence>
+        </div>
+        <h2 className="mb-8 text-[32px] font-medium text-black-700">
+          {data?.content}
+        </h2>
+        <span className="mb-9 block text-right text-2xl font-medium text-blue-400">
+          - {data?.author} -
+        </span>
+        <div className="flex items-center justify-center gap-4">
+          <button
+            type="button"
+            className="flex h-12 items-center justify-center gap-[6px] rounded-[100px] bg-black-600 px-5 text-white"
+          >
+            <Image
+              src="/icons/like-icon.svg"
+              width={23}
+              height={21}
+              alt="좋아요 아이콘"
+            />
+            {data?.likeCount}
+          </button>
+          <Link
+            href={data ? data?.referenceUrl : '/'}
+            className="flex h-12 items-center justify-center gap-[6px] rounded-[100px] bg-line-100 px-5 text-gray-300"
+          >
+            왕도로 가는길
+            <Image
+              src="/icons/share-icon.svg"
+              width={21}
+              height={21}
+              alt="공유 아이콘"
+            />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/epigram/src/components/detail/EpigramDetail.tsx
+++ b/epigram/src/components/detail/EpigramDetail.tsx
@@ -1,10 +1,7 @@
-import { fetchEpigramDetail } from '@/lib/apis/epigram';
 import { EpigramDetailType, Tag } from '@/lib/types/type';
-import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 interface EpigramDetailProps {

--- a/epigram/src/components/main/NewReviewList.tsx
+++ b/epigram/src/components/main/NewReviewList.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import Review from '../share/Review';
 import { useQuery } from '@tanstack/react-query';
 import { fetchNewComment } from '@/lib/apis/comment';
-import { CommentType } from '@/lib/types/type';
+import { CommentListType } from '@/lib/types/type';
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 
@@ -35,7 +35,7 @@ export default function NewReviewList() {
     <div className="mx-auto w-full max-w-[640px]">
       <h2 className="mb-10 text-2xl font-semibold text-black-600">최신 댓글</h2>
       {data.list.length > 0 ? (
-        data.list.map((comment: CommentType) => {
+        data.list.map((comment: CommentListType) => {
           return <Review key={comment.id} data={comment} userId={userId} />;
         })
       ) : (

--- a/epigram/src/components/share/Review.tsx
+++ b/epigram/src/components/share/Review.tsx
@@ -1,7 +1,7 @@
-import { CommentType } from '@/lib/types/type';
+import { CommentListType } from '@/lib/types/type';
 
 interface ReviewProps {
-  data: CommentType;
+  data: CommentListType;
   userId: number;
 }
 

--- a/epigram/src/lib/apis/comment.ts
+++ b/epigram/src/lib/apis/comment.ts
@@ -1,4 +1,4 @@
-import { CommentParamsType } from '../types/type';
+import { CommentDetailParamsType, CommentParamsType } from '../types/type';
 import axiosInstance from './instance';
 import { END_POINT } from './path';
 
@@ -15,5 +15,29 @@ export const fetchNewComment = async ({ limit, cursor }: CommentParamsType) => {
   } catch (error) {
     console.log('최신 댓글 api 에러', error);
     throw new Error('최신 댓글 데이터를 가져오는데 실패했습니다.');
+  }
+};
+
+// 에피그램 상세 댓글(get)
+export const fetchCommentDetail = async ({
+  id,
+  limit,
+  cursor,
+}: CommentDetailParamsType) => {
+  try {
+    const response = await axiosInstance.get(
+      END_POINT.epigram.detail.comments(id),
+      {
+        params: {
+          limit: limit,
+          cursor: cursor,
+        },
+      }
+    );
+
+    return response.data;
+  } catch (error) {
+    console.log('에피그램 상세 댓글 api 에러', error);
+    throw new Error('에피그램 상세 댓글 데이터를 가져오는데 실패했습니다.');
   }
 };

--- a/epigram/src/lib/apis/epigram.ts
+++ b/epigram/src/lib/apis/epigram.ts
@@ -31,3 +31,15 @@ export const fetchNewEpigram = async ({
     throw new Error('최신 에피그램 데이터를 가져오는데 실패했습니다.');
   }
 };
+
+// 에피그램 상세 정보(get)
+export const fetchEpigramDetail = async (id: string) => {
+  try {
+    const response = await axiosInstance.get(END_POINT.epigram.detail.base(id));
+
+    return response.data;
+  } catch (error) {
+    console.log('에피그램 상세 데이터 api 오류', error);
+    throw new Error('에피그램 상세 데이터를 가져오는데 실패했습니다.');
+  }
+};

--- a/epigram/src/lib/types/type.ts
+++ b/epigram/src/lib/types/type.ts
@@ -41,6 +41,11 @@ export interface EpigramType {
   tags: Tag[];
 }
 
+// 에피그램 상세 타입
+export interface EpigramDetailType extends EpigramType {
+  isLiked: boolean;
+}
+
 // 최신 에피그램 params
 export interface EpigramParamsType {
   limit: number;
@@ -55,6 +60,11 @@ export interface CommentParamsType {
   cursor?: number;
 }
 
+// 상세 댓글 params
+export interface CommentDetailParamsType extends CommentParamsType {
+  id: string;
+}
+
 // 댓글 작성자
 export interface Writer {
   image: string;
@@ -62,8 +72,8 @@ export interface Writer {
   id: number;
 }
 
-// 댓글 타입
-export interface CommentType {
+// 댓글 리스트 타입
+export interface CommentListType {
   epigramId: number;
   writer: Writer;
   updatedAt: string;
@@ -71,4 +81,11 @@ export interface CommentType {
   isPrivate: boolean;
   content: string;
   id: number;
+}
+
+// 댓글 타입
+export interface CommentType {
+  list: CommentListType[];
+  nextCursor: number | null;
+  totalCount: number;
 }

--- a/epigram/src/pages/feed/[id].tsx
+++ b/epigram/src/pages/feed/[id].tsx
@@ -1,169 +1,77 @@
-import Image from 'next/image';
-import { useState } from 'react';
+import CommentDetail from '@/components/detail/CommentDetail';
+import EpigramDetail from '@/components/detail/EpigramDetail';
+import { fetchCommentDetail } from '@/lib/apis/comment';
+import { fetchEpigramDetail } from '@/lib/apis/epigram';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 export default function DetailPage() {
-  const [isMenu, setIsMenu] = useState<boolean>(false);
+  const [userId, setUserId] = useState<number | null>(null); // 유저 id
+  const [isMore, setIsMore] = useState<boolean>(false); // 에피그램 드롭다운 버튼 display 상태
+
+  const router = useRouter();
+  const { id } = router.query; // url의 에피그램 id 쿼리값 가져오기
+
+  // 에피그램 상세 데이터
+  const {
+    data: epigramDetailData,
+    isLoading: epigramDetailLoading,
+    isError: epigramDetailError,
+  } = useQuery({
+    queryKey: ['epigramDetail', id, userId],
+    queryFn: async () => {
+      if (typeof id === 'string') {
+        const res = await fetchEpigramDetail(id);
+        if (userId === res.writerId) {
+          setIsMore(true);
+        } else {
+          setIsMore(false);
+        }
+        return res;
+      }
+    },
+    enabled: typeof id === 'string' && userId !== null,
+  });
+
+  // 에피그램 상세 댓글 데이터
+  const {
+    data: commentDetailData,
+    isLoading: commentDetailLoading,
+    isError: commentDetailError,
+  } = useQuery({
+    queryKey: ['commentDetail', id],
+    queryFn: async () => {
+      if (typeof id === 'string') {
+        const res = await fetchCommentDetail({ id: id, limit: 4, cursor: 0 });
+        return res;
+      }
+    },
+    enabled: typeof id === 'string',
+  });
+
+  // 로컬 스토리지에서 유저 id 가져오기
+  useEffect(() => {
+    const userInfo = localStorage.getItem('userInfo');
+    const userInfoParse = userInfo && JSON.parse(userInfo);
+    setUserId(userInfoParse?.id || null);
+  }, []);
+
+  const isLoading = epigramDetailLoading || commentDetailLoading;
+  const isError = epigramDetailError || commentDetailError;
+
+  if (isLoading) {
+    return <div>로딩중</div>;
+  }
+
+  if (isError) {
+    return <div>에러</div>;
+  }
 
   return (
     <div>
-      <div
-        className="bg-cover bg-center bg-repeat-x py-10"
-        style={{ backgroundImage: 'url(/images/back-line.png)' }}
-      >
-        <div className="mx-auto w-full max-w-[640px]">
-          <div className="relative mb-8 flex items-center justify-between">
-            <ul className="flex items-center gap-4 text-xl font-normal text-blue-400">
-              <li>#꿈을이루고싶을때</li>
-              <li>#나아가야할때</li>
-            </ul>
-            <button type="button">
-              <Image
-                src="/icons/more-icon.svg"
-                width={36}
-                height={36}
-                alt="더보기 버튼"
-              />
-            </button>
-            <ul className="absolute right-0 top-[52px] overflow-hidden rounded-2xl border-[1px] border-blue-300 bg-background text-xl font-normal">
-              <li className="px-8 py-3">
-                <button type="button">수정하기</button>
-              </li>
-              <li className="px-8 py-3">
-                <button type="button">삭제하기</button>
-              </li>
-            </ul>
-          </div>
-          <h2 className="mb-8 text-[32px] font-medium text-black-700">
-            오랫동안 꿈을 그리는 사람은 마침내 그 꿈을 닮아 간다.
-          </h2>
-          <span className="mb-9 block text-right text-2xl font-medium text-blue-400">
-            - 앙드레 말로 -
-          </span>
-          <div className="flex items-center justify-center gap-4">
-            <button
-              type="button"
-              className="flex h-12 items-center justify-center gap-[6px] rounded-[100px] bg-black-600 px-5 text-white"
-            >
-              <Image
-                src="/icons/like-icon.svg"
-                width={23}
-                height={21}
-                alt="좋아요 아이콘"
-              />
-              123
-            </button>
-            <button
-              type="button"
-              className="flex h-12 items-center justify-center gap-[6px] rounded-[100px] bg-line-100 px-5 text-gray-300"
-            >
-              왕도로 가는길
-              <Image
-                src="/icons/share-icon.svg"
-                width={21}
-                height={21}
-                alt="공유 아이콘"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div className="relative h-full bg-background py-12">
-        <div
-          className="absolute left-0 top-0 h-[15px] w-full bg-cover bg-center bg-repeat-x"
-          style={{ backgroundImage: 'url(/images/line-top.png)' }}
-        />
-        <div className="mx-auto w-full max-w-[640px]">
-          <h3 className="mb-6 text-xl font-semibold">댓글 (3)</h3>
-          <div className="mb-10 flex items-start gap-4">
-            <Image
-              src="/images/profile-default.png"
-              className="rounded-full"
-              width={48}
-              height={38}
-              alt="프로필 이미지"
-            />
-            <textarea
-              placeholder="100자 이내로 입력해주세요."
-              className="h-[104px] w-full resize-none rounded-lg border-[1px] border-line-200 bg-background px-4 py-3 focus-visible:outline-black-600"
-              maxLength={100}
-            ></textarea>
-          </div>
-
-          <div className="flex items-start gap-4 border-t-[1px] border-t-line-200 px-6 py-[35px]">
-            <Image
-              src="/images/profile-default.png"
-              className="rounded-full"
-              width={48}
-              height={38}
-              alt="프로필 이미지"
-            />
-            <div>
-              <div className="mb-4 flex items-center justify-between">
-                <div className="flex items-center gap-2 text-base font-normal text-black-300">
-                  <span>지킬과 하이드</span>
-                  <span>1시간 전</span>
-                </div>
-                <div className="flex items-center gap-4 text-base font-normal">
-                  <button type="button" className="text-black-600 underline">
-                    수정
-                  </button>
-                  <button type="button" className="text-red underline">
-                    삭제
-                  </button>
-                </div>
-              </div>
-              <p className="text-xl font-normal text-black-700">
-                오늘 하루 우울했었는데 덕분에 많은 힘 얻고 갑니다. 연금술사 책
-                다시 사서 오랜만에 읽어봐야겠어요!
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-start gap-4 border-t-[1px] border-t-line-200 px-6 py-[35px]">
-            <Image
-              src="/images/profile-default.png"
-              className="rounded-full"
-              width={48}
-              height={38}
-              alt="프로필 이미지"
-            />
-            <div>
-              <div className="mb-4 flex items-center justify-between">
-                <div className="flex items-center gap-2 text-base font-normal text-black-300">
-                  <span>지킬과 하이드</span>
-                  <span>1시간 전</span>
-                </div>
-              </div>
-              <p className="text-xl font-normal text-black-700">
-                오늘 하루 우울했었는데 덕분에 많은 힘 얻고 갑니다. 연금술사 책
-                다시 사서 오랜만에 읽어봐야겠어요!
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-start gap-4 border-t-[1px] border-t-line-200 px-6 py-[35px]">
-            <Image
-              src="/images/profile-default.png"
-              className="rounded-full"
-              width={48}
-              height={38}
-              alt="프로필 이미지"
-            />
-            <div>
-              <div className="mb-4 flex items-center justify-between">
-                <div className="flex items-center gap-2 text-base font-normal text-black-300">
-                  <span>지킬과 하이드</span>
-                  <span>1시간 전</span>
-                </div>
-              </div>
-              <p className="text-xl font-normal text-black-700">
-                오늘 하루 우울했었는데 덕분에 많은 힘 얻고 갑니다. 연금술사 책
-                다시 사서 오랜만에 읽어봐야겠어요!
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
+      <EpigramDetail data={epigramDetailData} isMore={isMore} />
+      <CommentDetail data={commentDetailData} userId={userId} />
     </div>
   );
 }


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 에피그램 피드 상세 페이지 api 구현&연동

# 작업 상세 내용
- 에피그램 상세 페이지 피드 데이터 연동
  - 본인이 작성한 피드일 경우 수정, 삭제 할 수 있는 드롭다운 메뉴 버튼 노출
  - framer-motion 라이브러리를 사용하여 드롭다운 메뉴 구현
- 해당 에피그램의 댓글 데이터 연동
  - 본인이 작성한 댓글일 경우 수정, 삭제 버튼 노출

![localhost_3000_feed_898](https://github.com/user-attachments/assets/788177d5-b0fb-49ed-b1c0-505ec7936b22)

# 리뷰 요구사항

_집중 리뷰 부분 작성_

# 연관된 이슈 번호
- #22 
