### PR TITLE
Feature: 마이페이지 감정 달력 기능 구현

### DIFF
--- a/epigram/package-lock.json
+++ b/epigram/package-lock.json
@@ -14,6 +14,7 @@
         "framer-motion": "^12.0.6",
         "next": "15.1.0",
         "react": "^19.0.0",
+        "react-calendar": "^5.1.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
         "ts-pattern": "^5.6.2",
@@ -691,6 +692,14 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -1162,6 +1171,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -1308,6 +1328,11 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -1326,11 +1351,48 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1371,6 +1433,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minimatch": {
@@ -1543,6 +1613,14 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -1885,6 +1963,30 @@
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
+      "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {
@@ -2360,6 +2462,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/epigram/package.json
+++ b/epigram/package.json
@@ -15,6 +15,7 @@
     "framer-motion": "^12.0.6",
     "next": "15.1.0",
     "react": "^19.0.0",
+    "react-calendar": "^5.1.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "ts-pattern": "^5.6.2",

--- a/epigram/public/icons/down-arrow-icon.svg
+++ b/epigram/public/icons/down-arrow-icon.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="12" viewBox="0 0 22 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 0.999999L11 11L1 1" stroke="#C4C4C4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/epigram/public/icons/left-arrow-icon.svg
+++ b/epigram/public/icons/left-arrow-icon.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="24" viewBox="0 0 14 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22L2 12L12 2" stroke="black" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/epigram/public/icons/right-arrow-icon.svg
+++ b/epigram/public/icons/right-arrow-icon.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="24" viewBox="0 0 14 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 2L12 12L2 22" stroke="black" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/epigram/src/components/myPage/CalendarEmotion.tsx
+++ b/epigram/src/components/myPage/CalendarEmotion.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from 'react';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import Image from 'next/image';
+import { useEmotion } from '@/lib/hooks/useEmotion';
+import { useQuery } from '@tanstack/react-query';
+import { fetchEmotionMonthly } from '@/lib/apis/emotion';
+import { useUserInfo } from '@/lib/hooks/useUserInfo';
+import { EmotionMonthlyType } from '@/lib/types/type';
+import CalendarFilter from './CalendarFilter';
+
+export default function CalendarEmotion() {
+  const [currentDate, setCurrentDate] = useState<any>(null);
+  const [viewDate, setViewDate] = useState<any>(new Date());
+  const { EMOTION_LIST } = useEmotion();
+  const { userData, userDataLoading, userDataError } = useUserInfo();
+  const [emotionFilter, setEmotionFilter] = useState<string | null>(null);
+  console.log(emotionFilter);
+
+  const {
+    data: emotionData,
+    isLoading: emotionLoading,
+    isError: emotionError,
+  } = useQuery({
+    queryKey: ['emotion', currentDate],
+    queryFn: async () => {
+      const monthsToFetch = [
+        {
+          // 현재 달
+          year: currentDate.getFullYear(),
+          month: currentDate.getMonth(),
+        },
+        {
+          // 이전 달
+          year:
+            currentDate.getMonth() === 0
+              ? currentDate.getFullYear() - 1
+              : currentDate.getFullYear(),
+          month: currentDate.getMonth() === 0 ? 11 : currentDate.getMonth() - 1,
+        },
+        {
+          // 다음 달
+          year:
+            currentDate.getMonth() === 11
+              ? currentDate.getFullYear() + 1
+              : currentDate.getFullYear(),
+          month: currentDate.getMonth() === 11 ? 0 : currentDate.getMonth() + 1,
+        },
+      ];
+
+      const res = await Promise.all(
+        monthsToFetch.map(({ year, month }) =>
+          fetchEmotionMonthly({
+            userId: userData?.id,
+            year,
+            month: month + 1,
+          })
+        )
+      );
+
+      return res;
+    },
+    enabled: !!currentDate && !!userData,
+  });
+  const allEmotionData = emotionData?.flat();
+
+  // 달력 이전달 이동
+  const handlePreviousMonth = () => {
+    const newDate = new Date(viewDate);
+    newDate.setMonth(viewDate.getMonth() - 1);
+    setViewDate(newDate);
+    setCurrentDate(newDate);
+  };
+
+  // 달력 다음달 이동
+  const handleNextMonth = () => {
+    const newDate = new Date(viewDate);
+    newDate.setMonth(viewDate.getMonth() + 1);
+    setViewDate(newDate);
+    setCurrentDate(newDate);
+  };
+
+  const findEmotionData = (date: any) => {
+    const matchData = allEmotionData?.find((emotion: EmotionMonthlyType) => {
+      const isSameDate =
+        new Date(emotion.createdAt).toDateString() === date.toDateString();
+      // emotionFilter가 없으면 모든 감정 데이터가 일치하도록
+      const isEmotionMatched =
+        !emotionFilter || emotion.emotion === emotionFilter;
+
+      return isSameDate && isEmotionMatched; // 날짜가 일치하면 모든 감정을 반환
+    });
+
+    if (matchData) {
+      return {
+        id: matchData.id,
+        emotion: matchData.emotion,
+        createdAt: matchData.createdAt,
+        userId: matchData.userId,
+      };
+    }
+  };
+
+  const findEmotionImage = (data: string) => {
+    const matchImage = EMOTION_LIST.find((emotion) => {
+      return emotion.id === data;
+    });
+
+    return matchImage?.image;
+  };
+
+  // 달력에 class 추가
+  const tileClassName = ({ date, view }: any) => {
+    if (view !== 'month') return '';
+
+    // 필터에 값이 있으면 해당 값과 일치하는지 여부 확인 없으면 필터적용없이 확인
+    const matchEmotion = emotionFilter
+      ? findEmotionData(date)?.emotion === emotionFilter
+      : findEmotionData(date);
+
+    // 해당 필터 값과 일치하는 날짜에만 클래스 추가
+    if (matchEmotion) {
+      return 'emotion';
+    }
+
+    return '';
+  };
+
+  // 달력에 감정 아이콘 추가
+  const tileContent = ({ date, view }: any) => {
+    if (view !== 'month') return '';
+
+    const matchEmotionDate = findEmotionData(date);
+    if (!matchEmotionDate) return null;
+    const matchEmotionImage = findEmotionImage(matchEmotionDate?.emotion);
+
+    if (matchEmotionImage) {
+      return (
+        <div className="emotionImage">
+          <Image
+            src={matchEmotionImage}
+            width={36}
+            height={36}
+            alt="감정 아이콘"
+          />
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  useEffect(() => {
+    setCurrentDate(new Date());
+  }, []);
+
+  if (emotionLoading && userDataLoading) return <div>로딩중</div>;
+
+  if (emotionError && userDataError) return <div>에러</div>;
+
+  return (
+    <div className="mb-40">
+      <div>달력 영역</div>
+      {currentDate && (
+        <div className="calendar-custom">
+          <div className="absolute right-0 top-0 flex h-[52px] items-center gap-6">
+            <button
+              type="button"
+              className="flex h-9 w-9 items-center justify-center"
+              onClick={handlePreviousMonth}
+            >
+              <Image
+                className="h-5 w-[10px]"
+                src="/icons/left-arrow-icon.svg"
+                width={10}
+                height={20}
+                alt="왼쪽 화살표"
+              />
+            </button>
+            <button
+              type="button"
+              className="flex h-9 w-9 items-center justify-center"
+              onClick={handleNextMonth}
+            >
+              <Image
+                className="h-5 w-[10px]"
+                src="/icons/right-arrow-icon.svg"
+                width={10}
+                height={20}
+                alt="오른쪽 화살표"
+              />
+            </button>
+          </div>
+          <CalendarFilter setEmotionFilter={setEmotionFilter} />
+          <Calendar
+            value={currentDate}
+            onChange={setCurrentDate}
+            selectRange={false}
+            locale="ko-KR"
+            calendarType="hebrew"
+            formatDay={(locale, date) => date.getDate().toString()}
+            next2Label={null}
+            prev2Label={null}
+            nextLabel={null}
+            prevLabel={null}
+            navigationLabel={({ label }) => (
+              <span className="text-2xl font-semibold text-black-600">
+                {label}
+              </span>
+            )}
+            onActiveStartDateChange={({ activeStartDate }) => {
+              setViewDate(activeStartDate); // 달력의 표시된 월만 변경
+            }}
+            activeStartDate={viewDate} // viewDate에 해당하는 월을 달력에 표시
+            tileClassName={tileClassName}
+            tileContent={tileContent}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/epigram/src/components/myPage/CalendarFilter.tsx
+++ b/epigram/src/components/myPage/CalendarFilter.tsx
@@ -1,0 +1,84 @@
+import { useEmotion } from '@/lib/hooks/useEmotion';
+import clsx from 'clsx';
+import Image from 'next/image';
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface CalendarFilterProps {
+  setEmotionFilter: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+export default function CalendarFilter({
+  setEmotionFilter,
+}: CalendarFilterProps) {
+  const [selectFilter, setSelectFilter] = useState<string>('없음');
+  const [isToggle, setIsToggle] = useState<boolean>(false);
+  const { EMOTION_LIST } = useEmotion();
+  return (
+    <>
+      <div className="absolute right-[120px] top-0 h-[52px] w-36">
+        <button
+          type="button"
+          className={clsx(
+            'flex h-full w-full items-center justify-center gap-2 rounded-[14px] bg-background text-xl font-semibold ',
+            isToggle
+              ? 'border-2 border-black-600 text-black-600'
+              : 'text-gray-200'
+          )}
+          onClick={() => {
+            setIsToggle(!isToggle);
+          }}
+        >
+          필터: {selectFilter}
+          <span className={clsx('text-3xl', isToggle && 'text-black-600')}>
+            ▾
+          </span>
+        </button>
+      </div>
+      <AnimatePresence>
+        {isToggle && (
+          <motion.div
+            initial={{ opacity: 0, y: -10, x: '-50%' }}
+            animate={{ opacity: 1, y: 0, x: '-50%' }}
+            exit={{ opacity: 0, y: -10, x: '-50%' }}
+            transition={{ duration: 0.3 }}
+            className="translate-x-[-50%]!important absolute left-[50%] top-[60px] w-full max-w-[560px] rounded-2xl bg-white shadow-[0_3px_16px_rgba(0,0,0,0.1)]"
+          >
+            <ul className="flex items-center justify-center gap-3 p-4">
+              {EMOTION_LIST.map((emotion) => {
+                return (
+                  <li className="w-full">
+                    <button
+                      type="button"
+                      className={clsx(
+                        'flex h-24 w-full max-w-24 items-center justify-center rounded-2xl bg-[#EBEEF3]',
+                        selectFilter === emotion?.text &&
+                          'border-4 border-[#FBC85B] bg-white'
+                      )}
+                      onClick={() => {
+                        if (selectFilter === emotion?.text) {
+                          setSelectFilter('없음');
+                          setEmotionFilter(null);
+                        } else {
+                          setSelectFilter(emotion?.text);
+                          setEmotionFilter(emotion?.id);
+                        }
+                      }}
+                    >
+                      <Image
+                        src={emotion?.image}
+                        width={48}
+                        height={48}
+                        alt="감정 아이콘"
+                      />
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/epigram/src/components/myPage/Profile.tsx
+++ b/epigram/src/components/myPage/Profile.tsx
@@ -24,7 +24,6 @@ export default function Profile() {
     logout();
     router.push('/');
   };
-  console.log(userData?.nickname);
 
   const imageUrl = async (imageFile: File) => {
     const formData = new FormData();

--- a/epigram/src/components/share/NavBar.tsx
+++ b/epigram/src/components/share/NavBar.tsx
@@ -1,11 +1,9 @@
-import { useAuth } from '@/lib/context/AuthContext';
 import { useUserInfo } from '@/lib/hooks/useUserInfo';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export default function NavBar() {
-  const { loginState } = useAuth();
-  const { userData } = useUserInfo();
+  const { loginState, userData } = useUserInfo();
 
   return (
     <header className="border-b-[1px] border-[#D7D7D7] px-5">
@@ -13,7 +11,7 @@ export default function NavBar() {
         <div className="mx-auto flex h-[80px] w-full max-w-[1680px] items-center justify-between gap-5">
           <div className="flex items-center gap-8">
             <h1>
-              <Link href={loginState ? '/main' : '/'}>
+              <Link href="/main">
                 <Image
                   src="/images/logo.png"
                   width={131}
@@ -48,7 +46,7 @@ export default function NavBar() {
                 }}
                 className="black h-9 w-9 rounded-full bg-white bg-cover bg-center"
               />
-              {userData?.nickname}
+              {userData?.nickname || '유저'}
             </Link>
           </div>
         </div>

--- a/epigram/src/lib/apis/emotion.ts
+++ b/epigram/src/lib/apis/emotion.ts
@@ -1,6 +1,8 @@
+import { EmotionMonthlyParamsType } from '../types/type';
 import axiosInstance from './instance';
 import { END_POINT } from './path';
 
+// 오늘의 감정 전송(post)
 export const postEmotion = async (emotion: string) => {
   try {
     const response = await axiosInstance.post(END_POINT.emotionLog.today, {
@@ -11,5 +13,43 @@ export const postEmotion = async (emotion: string) => {
   } catch (error) {
     console.log('오늘의 감정 전송 api 에러', error);
     throw new Error('오늘의 감정 데이터를 전송하는데 실패했습니다.');
+  }
+};
+
+// 오늘의 감정 가져오기(get)
+export const fetchEmotion = async (userId: number) => {
+  try {
+    const response = await axiosInstance.get(END_POINT.emotionLog.today, {
+      params: {
+        userId: userId,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log('오늘의 감정 가져오기 api 에러', error);
+    throw new Error('오늘의 감정 데이터 가져오는데 실패했습니다.');
+  }
+};
+
+// 날짜에 대한 감정 가져오기(get)
+export const fetchEmotionMonthly = async ({
+  userId,
+  year,
+  month,
+}: EmotionMonthlyParamsType) => {
+  try {
+    const response = await axiosInstance.get(END_POINT.emotionLog.monthly, {
+      params: {
+        userId: userId,
+        year: year,
+        month: month,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log('월별 감정 감져오기 api 에러', error);
+    throw new Error('월별 감정 가져오는데 실패했습니다.');
   }
 };

--- a/epigram/src/lib/hooks/useEmotion.ts
+++ b/epigram/src/lib/hooks/useEmotion.ts
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { postEmotion } from '../apis/emotion';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEmotionStore } from '../store/useEmotionStore';
+
+interface EmotionType {
+  emotionId: string;
+  emotionText: string;
+  emotionImage: string;
+}
+
+export const useEmotion = () => {
+  const EMOTION_LIST = [
+    {
+      id: 'MOVED',
+      text: '감동',
+      image: '/images/face-inspiration.png',
+    },
+    {
+      id: 'HAPPY',
+      text: '기쁨',
+      image: '/images/face-joy.png',
+    },
+    {
+      id: 'WORRIED',
+      text: '고민',
+      image: '/images/face-thinking.png',
+    },
+    {
+      id: 'SAD',
+      text: '슬픔',
+      image: '/images/face-sad.png',
+    },
+    {
+      id: 'ANGRY',
+      text: '분노',
+      image: '/images/face-anger.png',
+    },
+  ];
+  const queryClient = useQueryClient();
+  const { emotion, setEmotion } = useEmotionStore();
+
+  // 오늘의 감정 선택
+  const handleEmotionClick = async ({
+    emotionId,
+    emotionText,
+    emotionImage,
+  }: EmotionType) => {
+    setEmotion({ id: emotionId, text: emotionText, image: emotionImage });
+    try {
+      await postEmotion(emotionId);
+      queryClient.invalidateQueries<any>(['emotion']);
+    } catch (error) {
+      console.log('감정 데이터 전송 api 호출 에러', error);
+    }
+  };
+
+  return { EMOTION_LIST, emotion, setEmotion, handleEmotionClick };
+};

--- a/epigram/src/lib/hooks/useUserInfo.ts
+++ b/epigram/src/lib/hooks/useUserInfo.ts
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchUserInfo } from '../apis/api';
+import { useAuth } from '../context/AuthContext';
 
 export const useUserInfo = () => {
+  const { loginState } = useAuth();
   const {
     data: userData,
     isLoading: userDataLoading,
@@ -15,7 +17,15 @@ export const useUserInfo = () => {
 
       return res;
     },
+    enabled: loginState,
   });
 
-  return { userData, userDataLoading, userDataError, error, refetch };
+  return {
+    loginState,
+    userData,
+    userDataLoading,
+    userDataError,
+    error,
+    refetch,
+  };
 };

--- a/epigram/src/lib/store/useEmotionStore.ts
+++ b/epigram/src/lib/store/useEmotionStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface uploadEmotionType {
+  id: string;
+  text: string;
+  image: string;
+}
+
+interface useEmotionStoreType {
+  emotion: uploadEmotionType;
+  setEmotion: (uploadEmotion: uploadEmotionType) => void;
+}
+
+export const useEmotionStore = create<useEmotionStoreType>((set) => ({
+  emotion: {
+    id: 'MOVED',
+    text: '감동',
+    image: '/images/face-inspiration.png',
+  },
+  setEmotion: (uploadEmotion: uploadEmotionType) =>
+    set(() => ({ emotion: uploadEmotion })),
+}));

--- a/epigram/src/lib/types/type.ts
+++ b/epigram/src/lib/types/type.ts
@@ -129,3 +129,17 @@ export type PatchComment = Pick<CommentPostType, 'isPrivate' | 'content'> & {
 
 // 댓글 수정 함수 타입
 export type modifyComment = Pick<CommentPostType, 'isPrivate' | 'content'>;
+
+// 월별 감정 조회 타입
+export interface EmotionMonthlyParamsType {
+  userId: number;
+  year: number;
+  month: number;
+}
+
+export interface EmotionMonthlyType {
+  id: number;
+  userId: number;
+  emotion: string;
+  createdAt: string;
+}

--- a/epigram/src/pages/index.tsx
+++ b/epigram/src/pages/index.tsx
@@ -2,6 +2,7 @@ import ImageContent from '@/components/landing/ImageContent';
 import KeyVisual from '@/components/landing/KeyVisual';
 import LandingLast from '@/components/landing/LandingLast';
 import UserEpigram from '@/components/landing/UserEpigram';
+import CalendarEmotion from '@/components/myPage/CalendarEmotion';
 
 export default function Landing() {
   return (

--- a/epigram/src/pages/myPage/index.tsx
+++ b/epigram/src/pages/myPage/index.tsx
@@ -1,4 +1,5 @@
 import TodayState from '@/components/main/TodayState';
+import CalendarEmotion from '@/components/myPage/CalendarEmotion';
 import ContentAllList from '@/components/myPage/ContentAllList';
 import Profile from '@/components/myPage/Profile';
 
@@ -11,7 +12,7 @@ export default function MyPage() {
 
           <TodayState />
 
-          <div className="mb-40">달력 영역</div>
+          <CalendarEmotion />
 
           <div>
             <h2 className="mb-12 text-2xl font-semibold text-black-600">

--- a/epigram/src/styles/calendar.css
+++ b/epigram/src/styles/calendar.css
@@ -1,0 +1,108 @@
+.calendar-custom {
+  width: 100%;
+  position: relative;
+}
+
+.calendar-custom .react-calendar {
+  width: 100%;
+  border: none;
+}
+
+.calendar-custom .react-calendar .react-calendar__navigation {
+  height: 52px;
+  margin-bottom: 48px;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__navigation
+  .react-calendar__navigation__label {
+  flex-grow: 0 !important;
+  width: 140px;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__weekdays__weekday {
+  display: flex;
+  height: 91px;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+  font-weight: 600;
+  color: #c4c4c4;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__weekdays__weekday
+  abbr {
+  text-decoration: none;
+}
+
+.calendar-custom .react-calendar .react-calendar__month-view__weekdays {
+  border-top: 1px solid #eceff4;
+  border-bottom: 1px solid #eceff4;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__days
+  .react-calendar__tile {
+  display: flex;
+  height: 91px;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+  font-weight: 600;
+  border-bottom: 1px solid #eceff4;
+  color: #c4c4c4;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__days
+  .react-calendar__tile.emotion {
+  flex-direction: column;
+  gap: 12px;
+  font-size: 16px;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__days
+  .react-calendar__tile.react-calendar__tile--now,
+.calendar-custom
+  .react-calendar
+  .react-calendar__year-view
+  .react-calendar__year-view__months
+  .react-calendar__tile.react-calendar__tile--now {
+  color: #ff6577;
+  border: 6px solid #ff6577;
+  border-radius: 3px;
+  background-color: white;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__days
+  .react-calendar__tile.react-calendar__tile--now.react-calendar__tile--active,
+.calendar-custom
+  .react-calendar
+  .react-calendar__year-view
+  .react-calendar__year-view__months
+  .react-calendar__tile.react-calendar__tile--now.react-calendar__tile--hasActive {
+  background-color: white;
+}
+
+.calendar-custom
+  .react-calendar
+  .react-calendar__month-view__days
+  .react-calendar__tile.react-calendar__tile--active,
+.calendar-custom
+  .react-calendar
+  .react-calendar__year-view
+  .react-calendar__year-view__months
+  .react-calendar__tile.react-calendar__tile--hasActive {
+  background-color: #f5f7fa;
+}

--- a/epigram/src/styles/globals.css
+++ b/epigram/src/styles/globals.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import url(calendar.css);
 @import url(font.css);
 
 body {


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 마이페이지 감정 달력 기능 구현

# 작업 상세 내용
- 리액트 캘린더를 사용하여 감정 달력 구현
  - 디자인 커스텀을 하기위해 달력의 이전달 다음달 이동 기능 따로 구현
- zustand를 사용하여 감정 상태를 전역으로 관리하도록 구현
- 감정 달력 필터 컴포넌트 따로 만들어서 필터 기능 구현
- 로그인 관련 수정
  - 유저 정보 커스텀 훅에 로그인 상태 관리하는 전역 컨텍스트 적용
 
https://github.com/user-attachments/assets/fee3face-9a53-4ffe-88e9-750a07ae33c8

# 리뷰 요구사항

_집중 리뷰 부분 작성_

# 연관된 이슈 번호
- #31 
