### PR TITLE
Feature: 더보기&무한 스크롤 기능 구현

### DIFF
--- a/epigram/src/components/main/NewEpigramList.tsx
+++ b/epigram/src/components/main/NewEpigramList.tsx
@@ -1,23 +1,36 @@
 import Link from 'next/link';
 import clsx from 'clsx';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchNewEpigram } from '@/lib/apis/epigram';
 import { EpigramType } from '@/lib/types/type';
 import Epigram from '../share/Epigram';
+import { useEffect } from 'react';
 
 interface NewEpigramProps {
   marginBottom?: string;
 }
 
 export default function NewEpigramList({ marginBottom }: NewEpigramProps) {
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['newEpigram'],
-    queryFn: async () => {
-      const res = await fetchNewEpigram({ limit: 3, cursor: 0 });
-      console.log(res);
-      return res;
-    },
-  });
+  const queryClient = useQueryClient();
+  const { data, fetchNextPage, hasNextPage, isLoading, isError } =
+    useInfiniteQuery({
+      queryKey: ['newEpigram'],
+      queryFn: async ({ pageParam = 0 }) => {
+        const res = await fetchNewEpigram({ limit: 3, cursor: pageParam });
+        return res;
+      },
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      initialPageParam: 0,
+    });
+  // 더보기 갯수 최대 10개로 제한
+  const MAX_ITEMS = 10;
+  const totalItems =
+    data?.pages?.reduce((acc, page) => acc + page?.list?.length, 0) ?? 0;
+  const isMoreButton = totalItems < MAX_ITEMS && hasNextPage;
+
+  useEffect(() => {
+    queryClient.resetQueries<any>(['newEpigram']);
+  }, []);
 
   if (isLoading) {
     return <div>로딩중...</div>;
@@ -36,16 +49,29 @@ export default function NewEpigramList({ marginBottom }: NewEpigramProps) {
       <h2 className="mb-10 text-2xl font-semibold text-black-600">
         최신 에피그램
       </h2>
-      {data?.list.map((epigram: EpigramType) => {
-        return <Epigram key={epigram.id} data={epigram} />;
-      })}
+      {data?.pages?.flatMap(({ list }) =>
+        list?.map((epigram: EpigramType) => {
+          return <Epigram key={epigram.id} data={epigram} />;
+        })
+      )}
+
       <div className="flex justify-center">
-        <Link
-          href="/feed"
-          className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
-        >
-          + 에프기램 더보기
-        </Link>
+        {isMoreButton ? (
+          <button
+            type="button"
+            onClick={() => fetchNextPage()}
+            className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+          >
+            + 에피그램 더보기
+          </button>
+        ) : (
+          <Link
+            href="/feed"
+            className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+          >
+            + 전체 에피그램 보기
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/epigram/src/components/myPage/ChartEmotion.tsx
+++ b/epigram/src/components/myPage/ChartEmotion.tsx
@@ -166,7 +166,9 @@ export default function ChartEmotion() {
                     height={24}
                     alt="감정 이미지"
                   />{' '}
-                  <span className="w-[50px] text-right">{item.y}%</span>
+                  <span className="w-[50px] text-right">
+                    {item.y.toFixed(1)}%
+                  </span>
                 </li>
               );
             })}

--- a/epigram/src/components/myPage/ContentAllList.tsx
+++ b/epigram/src/components/myPage/ContentAllList.tsx
@@ -1,21 +1,21 @@
 import clsx from 'clsx';
 import { useState } from 'react';
 import { match } from 'ts-pattern';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchNewEpigram } from '@/lib/apis/epigram';
 import { useUserInfo } from '@/lib/hooks/useUserInfo';
 import { fetchMyCommentList } from '@/lib/apis/comment';
-import Image from 'next/image';
-import Comment from '../share/Comment';
-import { CommentListType, EpigramType, modifyComment } from '@/lib/types/type';
+import { modifyComment } from '@/lib/types/type';
 import { useDeleteComment } from '@/lib/hooks/useDeleteComment';
 import { useModifyComment } from '@/lib/hooks/useModifyComment';
 import ModalFrame from '../modal/ModalFrame';
 import CommentModifyModal from '../modal/CommentModifyModal';
 import CommentDeleteModal from '../modal/CommentDeleteModal';
 import MyEpigramList from './MyEpigramList';
+import MyCommentList from './MyCommentList';
 
 export default function ContentAllList() {
+  const queryClient = useQueryClient();
   const EPIGRAM_LIST_LIMIT = 3;
   const COMMENT_LIST_LIMIT = 3;
   const EPIGRAM = 'epigram';
@@ -23,23 +23,22 @@ export default function ContentAllList() {
   const [myPageTab, setMyPageTab] = useState<string>(EPIGRAM);
   const { userData } = useUserInfo();
 
-  const { isOpen, setIsOpen, setCommentId, handleDeleteComment } =
-    useDeleteComment();
+  const { isOpen, setIsOpen, handleDeleteComment } = useDeleteComment();
 
   const {
     isOpen: modifyIsOpen,
     setIsOpen: modifySetIsOpen,
-    setCommentId: modifySetCommentId,
     handleModifyComment,
   } = useModifyComment();
 
   // 마이페이지 에피그램 리스트 데이터
   const {
     data: epigramData,
-    fetchNextPage,
-    hasNextPage,
+    fetchNextPage: epigramFetchNextPage,
+    hasNextPage: epigramHasNextPage,
     isLoading: epigramLoading,
     isError: epigramError,
+    refetch: epigramRefetch,
   } = useInfiniteQuery({
     queryKey: ['myEpigram'],
     queryFn: async ({ pageParam = 0 }) => {
@@ -54,41 +53,60 @@ export default function ContentAllList() {
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     initialPageParam: 0,
   });
-  // 에피그램 총 갯수
-  const myEpigramListTotalCount = epigramData?.pages[0].totalCount;
 
   // 마이페이지 댓글 리스트 데이터
   const {
     data: commentData,
+    fetchNextPage: commentFetchNextPage,
+    hasNextPage: commentHasNextPage,
     isLoading: commentIsLoading,
     isError: commentIsError,
-    refetch,
-  } = useQuery({
+    refetch: commentRefetch,
+  } = useInfiniteQuery({
     queryKey: ['myComment'],
-    queryFn: async () => {
+    queryFn: async ({ pageParam = 0 }) => {
       const res = await fetchMyCommentList({
-        id: userData.id,
+        id: userData?.id,
         limit: COMMENT_LIST_LIMIT,
-        cursor: 0,
+        cursor: pageParam,
       });
       return res;
     },
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    initialPageParam: 0,
+    enabled: !!userData?.id,
   });
+
+  // 에피그램 총 갯수
+  const myEpigramListTotalCount = epigramData?.pages[0].totalCount;
+
+  // 댓글 총 갯수
+  const myCommentListTotalCount = commentData?.pages[0].totalCount;
 
   const handleTab = (tab: string) => {
     setMyPageTab(tab);
   };
 
   const deleteComment = () => {
-    handleDeleteComment({ commentRefetch: refetch });
+    handleDeleteComment({ commentRefetch: commentRefetch });
   };
 
   const modifyComment = ({ isPrivate, content }: modifyComment) => {
     handleModifyComment({
-      commentRefetch: refetch,
+      commentRefetch: commentRefetch,
       isPrivate: isPrivate,
       content: content,
     });
+  };
+
+  const ep = () => {
+    queryClient.resetQueries<any>('myComment');
+    handleTab(EPIGRAM);
+  };
+
+  const co = () => {
+    queryClient.resetQueries<any>('myEpigram');
+    handleTab(COMMENT);
   };
 
   if (epigramLoading && commentIsLoading) {
@@ -123,7 +141,7 @@ export default function ContentAllList() {
               'text-2xl',
               myPageTab === EPIGRAM && 'font-semibold'
             )}
-            onClick={() => handleTab(EPIGRAM)}
+            onClick={ep}
           >
             내 에피그램({myEpigramListTotalCount})
           </button>
@@ -133,51 +151,25 @@ export default function ContentAllList() {
               'text-2xl',
               myPageTab === COMMENT && 'font-semibold'
             )}
-            onClick={() => handleTab(COMMENT)}
+            onClick={co}
           >
-            내 댓글({commentData?.totalCount})
+            내 댓글({myCommentListTotalCount})
           </button>
         </div>
         {match(myPageTab)
           .with(EPIGRAM, () => (
             <MyEpigramList
               epigramData={epigramData}
-              fetchNextPage={fetchNextPage}
-              hasNextPage={hasNextPage}
+              fetchNextPage={epigramFetchNextPage}
+              hasNextPage={epigramHasNextPage}
             />
           ))
           .with(COMMENT, () => (
-            <div>
-              {commentData?.list && commentData.list.length > 0 ? (
-                commentData.list.map((comment: CommentListType) => {
-                  return (
-                    <Comment
-                      key={comment.id}
-                      data={comment}
-                      userId={userData.id}
-                      setIsOpen={setIsOpen}
-                      setCommentId={setCommentId}
-                      modifySetIsOpen={modifySetIsOpen}
-                      modifySetCommentId={modifySetCommentId}
-                    />
-                  );
-                })
-              ) : (
-                <div className="my-40 flex flex-col items-center justify-center gap-6">
-                  <Image
-                    src="/images/not-content.png"
-                    width={144}
-                    height={144}
-                    alt="댓글이 없는경우 아이콘"
-                  />
-                  <p className="text-center text-xl font-normal leading-[1.5] text-black-600">
-                    아직 댓글이 없어요!
-                    <br />
-                    댓글을 달고 다른 사람들과 교류해보세요.
-                  </p>
-                </div>
-              )}
-            </div>
+            <MyCommentList
+              commentData={commentData}
+              fetchNextPage={commentFetchNextPage}
+              hasNextPage={commentHasNextPage}
+            />
           ))
           .otherwise(() => '')}
       </div>

--- a/epigram/src/components/myPage/MyCommentList.tsx
+++ b/epigram/src/components/myPage/MyCommentList.tsx
@@ -1,0 +1,126 @@
+import { CommentListType, CommentScrollType } from '@/lib/types/type';
+import Image from 'next/image';
+import Comment from '../share/Comment';
+import { useDeleteComment } from '@/lib/hooks/useDeleteComment';
+import { useModifyComment } from '@/lib/hooks/useModifyComment';
+import { useUserInfo } from '@/lib/hooks/useUserInfo';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+interface MyCommentList {
+  commentData: CommentScrollType | undefined;
+  fetchNextPage: () => any;
+  hasNextPage: boolean;
+}
+
+export default function MyCommentList({
+  commentData,
+  hasNextPage,
+  fetchNextPage,
+}: MyCommentList) {
+  const queryClient = useQueryClient();
+  const { userData } = useUserInfo();
+  const { setIsOpen, setCommentId } = useDeleteComment();
+
+  const { setIsOpen: modifySetIsOpen, setCommentId: modifySetCommentId } =
+    useModifyComment();
+  const [isCollapse, setIsCollapse] = useState<boolean>(false);
+
+  // 더보기 기능
+  const moreClick = () => {
+    fetchNextPage();
+    setIsCollapse(true);
+  };
+
+  // 접기 기능
+  const collapseClick = () => {
+    queryClient.resetQueries<any>(['myComment']);
+    setIsCollapse(false);
+  };
+  return (
+    <div>
+      {commentData?.pages && commentData.pages?.length > 0 ? (
+        <>
+          {commentData.pages?.flatMap(({ list }) =>
+            list?.map((comment: CommentListType) => {
+              return (
+                <Comment
+                  key={comment.id}
+                  data={comment}
+                  userId={userData?.id}
+                  setIsOpen={setIsOpen}
+                  setCommentId={setCommentId}
+                  modifySetIsOpen={modifySetIsOpen}
+                  modifySetCommentId={modifySetCommentId}
+                />
+              );
+            })
+          )}
+          <div className="mt-14 flex justify-center">
+            {hasNextPage && (
+              <button
+                type="button"
+                onClick={moreClick}
+                className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+              >
+                + 에피그램 더보기
+              </button>
+            )}
+            {!hasNextPage && isCollapse && (
+              <button
+                type="button"
+                onClick={collapseClick}
+                className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+              >
+                - 에피그램 접기
+              </button>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="my-40 flex flex-col items-center justify-center gap-6">
+          <Image
+            src="/images/not-content.png"
+            width={144}
+            height={144}
+            alt="댓글이 없는경우 아이콘"
+          />
+          <p className="text-center text-xl font-normal leading-[1.5] text-black-600">
+            아직 댓글이 없어요!
+            <br />
+            댓글을 달고 다른 사람들과 교류해보세요.
+          </p>
+        </div>
+      )}
+      {/* {commentData?.list && commentData.list.length > 0 ? (
+        commentData.list.map((comment: CommentListType) => {
+          return (
+            <Comment
+              key={comment.id}
+              data={comment}
+              userId={userData.id}
+              setIsOpen={setIsOpen}
+              setCommentId={setCommentId}
+              modifySetIsOpen={modifySetIsOpen}
+              modifySetCommentId={modifySetCommentId}
+            />
+          );
+        })
+      ) : (
+        <div className="my-40 flex flex-col items-center justify-center gap-6">
+          <Image
+            src="/images/not-content.png"
+            width={144}
+            height={144}
+            alt="댓글이 없는경우 아이콘"
+          />
+          <p className="text-center text-xl font-normal leading-[1.5] text-black-600">
+            아직 댓글이 없어요!
+            <br />
+            댓글을 달고 다른 사람들과 교류해보세요.
+          </p>
+        </div>
+      )} */}
+    </div>
+  );
+}

--- a/epigram/src/components/myPage/MyEpigramList.tsx
+++ b/epigram/src/components/myPage/MyEpigramList.tsx
@@ -1,7 +1,7 @@
 import { EpigramScrollType, EpigramType } from '@/lib/types/type';
 import Image from 'next/image';
 import Epigram from '../share/Epigram';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 interface MyEpigramListProps {

--- a/epigram/src/components/myPage/MyEpigramList.tsx
+++ b/epigram/src/components/myPage/MyEpigramList.tsx
@@ -1,0 +1,79 @@
+import { EpigramScrollType, EpigramType } from '@/lib/types/type';
+import Image from 'next/image';
+import Epigram from '../share/Epigram';
+import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+interface MyEpigramListProps {
+  epigramData: EpigramScrollType | undefined;
+  fetchNextPage: () => any;
+  hasNextPage: boolean;
+}
+
+export default function MyEpigramList({
+  epigramData,
+  hasNextPage,
+  fetchNextPage,
+}: MyEpigramListProps) {
+  const queryClient = useQueryClient();
+  const [isCollapse, setIsCollapse] = useState<boolean>(false);
+
+  // 더보기 기능
+  const moreClick = () => {
+    fetchNextPage();
+    setIsCollapse(true);
+  };
+
+  // 접기 기능
+  const collapseClick = () => {
+    queryClient.resetQueries<any>(['myEpigram']);
+    setIsCollapse(false);
+  };
+  return (
+    <div>
+      {epigramData?.pages && epigramData.pages.length > 0 ? (
+        <>
+          {epigramData.pages?.flatMap(({ list }) =>
+            list?.map((epigram: EpigramType) => {
+              return <Epigram key={epigram.id} data={epigram} />;
+            })
+          )}
+          <div className="flex justify-center">
+            {hasNextPage && (
+              <button
+                type="button"
+                onClick={moreClick}
+                className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+              >
+                + 에피그램 더보기
+              </button>
+            )}
+            {!hasNextPage && isCollapse && (
+              <button
+                type="button"
+                onClick={collapseClick}
+                className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
+              >
+                - 에피그램 접기
+              </button>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="my-40 flex flex-col items-center justify-center gap-6">
+          <Image
+            src="/images/not-content.png"
+            width={144}
+            height={144}
+            alt="피드가 없는 경우 아이콘"
+          />
+          <p className="text-center text-xl font-normal leading-[1.5] text-black-600">
+            아직 에피그램이 없어요!
+            <br />
+            에피그램을 작성하고 다른 사람들과 교류해보세요.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/epigram/src/components/share/Epigram.tsx
+++ b/epigram/src/components/share/Epigram.tsx
@@ -11,15 +11,19 @@ export default function Epigram({ data, height }: EpigramProps) {
   const router = useRouter();
 
   const navigateToPage = () => {
-    router.push(`/feed/${data?.id}`);
+    if (data?.id) {
+      router.push(`/feed/${data.id}`);
+    }
   };
   return (
     <div className="mx-auto w-full max-w-[640px]">
       <div style={{ marginBottom: height ? '0px' : '56px' }}>
         <div
           className={clsx(
-            'mb-2 flex w-full cursor-pointer flex-col gap-5 rounded-2xl bg-cover bg-center bg-repeat-x p-6 shadow-[0_3px_12px_rgba(0,0,0,0.1)]',
-            data ? 'justify-between' : 'justify-center'
+            'mb-2 flex w-full flex-col gap-5 rounded-2xl bg-cover bg-center bg-repeat-x p-6 shadow-[0_3px_12px_rgba(0,0,0,0.1)]',
+            data
+              ? 'cursor-pointer justify-between'
+              : 'cursor-auto justify-center'
           )}
           style={{
             backgroundImage: 'url(/images/back-line.png)',

--- a/epigram/src/components/share/FixedMenu.tsx
+++ b/epigram/src/components/share/FixedMenu.tsx
@@ -2,6 +2,13 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 export default function FixedMenu() {
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
   return (
     <>
       <Link
@@ -12,6 +19,7 @@ export default function FixedMenu() {
       </Link>
       <button
         type="button"
+        onClick={scrollToTop}
         className="fixed bottom-[12%] right-28 flex h-16 w-16 items-center justify-center rounded-full bg-blue-900"
       >
         <Image

--- a/epigram/src/components/share/FixedMenu.tsx
+++ b/epigram/src/components/share/FixedMenu.tsx
@@ -1,13 +1,33 @@
+import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 export default function FixedMenu() {
+  const [showTopButton, setShowTopButton] = useState<boolean>(false);
+
+  const handleScroll = () => {
+    if (window.scrollY > 100) {
+      setShowTopButton(true);
+    } else {
+      setShowTopButton(false);
+    }
+  };
+
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
       behavior: 'smooth',
     });
   };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   return (
     <>
@@ -17,10 +37,17 @@ export default function FixedMenu() {
       >
         + 에피그램 만들기
       </Link>
+
       <button
         type="button"
         onClick={scrollToTop}
-        className="fixed bottom-[12%] right-28 flex h-16 w-16 items-center justify-center rounded-full bg-blue-900"
+        className={clsx(
+          'fixed bottom-[12%] right-28 flex h-16 w-16 items-center justify-center rounded-full bg-blue-900 transition-opacity duration-500 ease-in-out',
+          {
+            'pointer-events-auto opacity-100': showTopButton,
+            'pointer-events-none opacity-0': !showTopButton,
+          }
+        )}
       >
         <Image
           src="/icons/top-arrow-icon.svg"

--- a/epigram/src/components/share/NavBar.tsx
+++ b/epigram/src/components/share/NavBar.tsx
@@ -52,7 +52,7 @@ export default function NavBar() {
         </div>
       ) : (
         <div className="mx-auto flex h-[80px] w-full max-w-[1680px] items-center justify-between">
-          <Link href="/search">
+          <Link href="/search" className="w-28">
             <Image
               src="/icons/search-icon.svg"
               width={36}

--- a/epigram/src/lib/hooks/useInfiniteScroll.ts
+++ b/epigram/src/lib/hooks/useInfiniteScroll.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+interface useInfiniteScrollProps {
+  data: any;
+  hasNextPage: boolean;
+  fetchNextPage: () => any;
+}
+
+export const useInfiniteScroll = ({
+  data,
+  hasNextPage,
+  fetchNextPage,
+}: useInfiniteScrollProps) => {
+  const [scrollLoading, setScrollLoading] = useState<boolean>(false);
+  const totalCount = data?.pages[0].totalCount;
+  const currentCount =
+    data?.pages?.reduce((acc: any, page: any) => acc + page?.list.length, 0) ??
+    0;
+  const isMoreButton = currentCount >= Number(totalCount) ? false : hasNextPage;
+
+  useEffect(() => {
+    if (hasNextPage) {
+      const handleScroll = () => {
+        if (
+          window.innerHeight + document.documentElement.scrollTop >=
+          document.documentElement.offsetHeight - 1
+        ) {
+          if (!scrollLoading) {
+            setScrollLoading(true);
+            fetchNextPage().finally(() => setScrollLoading(false));
+          }
+        }
+      };
+      window.addEventListener('scroll', handleScroll);
+
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+      };
+    }
+  }, [hasNextPage, scrollLoading]);
+
+  return { totalCount, isMoreButton, scrollLoading };
+};

--- a/epigram/src/lib/types/type.ts
+++ b/epigram/src/lib/types/type.ts
@@ -71,6 +71,12 @@ export interface EpigramListType {
   totalCount: number;
 }
 
+// 에피그램 더보기 타입
+export interface EpigramScrollType {
+  pageParams: unknown[];
+  pages: EpigramListType[];
+}
+
 // 최신 에피그램 params
 export interface EpigramParamsType {
   limit: number;

--- a/epigram/src/lib/types/type.ts
+++ b/epigram/src/lib/types/type.ts
@@ -115,6 +115,12 @@ export interface CommentType {
   totalCount: number;
 }
 
+// 댓글 무한 스크롤 타입
+export interface CommentScrollType {
+  pageParams: unknown[];
+  pages: CommentType[];
+}
+
 // 댓글 작성 타입
 export interface CommentPostType {
   epigramId: number;

--- a/epigram/src/pages/feed/[id].tsx
+++ b/epigram/src/pages/feed/[id].tsx
@@ -5,11 +5,12 @@ import { fetchEpigramDetail } from '@/lib/apis/epigram';
 import { useUserInfo } from '@/lib/hooks/useUserInfo';
 import { CommentType, EpigramDetailType } from '@/lib/types/type';
 import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 export default function DetailPage() {
-  const { userData } = useUserInfo(); // 유저 정보
+  const { userData, loginState } = useUserInfo(); // 유저 정보
   const [isMore, setIsMore] = useState<boolean>(false); // 에피그램 드롭다운 버튼 display 상태
 
   const router = useRouter();
@@ -61,6 +62,23 @@ export default function DetailPage() {
 
   const isLoading = epigramDetailLoading || commentDetailLoading;
   const isError = epigramDetailError || commentDetailError;
+
+  if (!loginState) {
+    return (
+      <div
+        className="flex w-full flex-col items-center justify-center gap-10 px-5"
+        style={{ height: 'calc(100vh - 80px)' }}
+      >
+        <h2 className="text-3xl">로그인 후 이용해 주세요!</h2>
+        <Link
+          href="/login"
+          className="flex h-16 w-72 items-center justify-center rounded-xl bg-black-500 text-xl font-semibold text-white"
+        >
+          로그인 하러 가기
+        </Link>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return <div>로딩중</div>;

--- a/epigram/src/pages/feed/[id].tsx
+++ b/epigram/src/pages/feed/[id].tsx
@@ -3,13 +3,18 @@ import EpigramDetail from '@/components/detail/EpigramDetail';
 import { fetchCommentDetail } from '@/lib/apis/comment';
 import { fetchEpigramDetail } from '@/lib/apis/epigram';
 import { useUserInfo } from '@/lib/hooks/useUserInfo';
-import { CommentType, EpigramDetailType } from '@/lib/types/type';
-import { useQuery } from '@tanstack/react-query';
+import { EpigramDetailType } from '@/lib/types/type';
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 export default function DetailPage() {
+  const queryClient = useQueryClient();
   const { userData, loginState } = useUserInfo(); // 유저 정보
   const [isMore, setIsMore] = useState<boolean>(false); // 에피그램 드롭다운 버튼 display 상태
 
@@ -42,26 +47,36 @@ export default function DetailPage() {
   // 에피그램 상세 댓글 데이터
   const {
     data: commentDetailData,
+    fetchNextPage,
+    hasNextPage,
     isLoading: commentDetailLoading,
     isError: commentDetailError,
     refetch,
-  } = useQuery<CommentType>({
+  } = useInfiniteQuery({
     queryKey: ['commentDetail', Number(commentId)],
-    queryFn: async () => {
+    queryFn: async ({ pageParam = 0 }) => {
       if (typeof id === 'string') {
         const res = await fetchCommentDetail({
           id: Number(id),
           limit: 4,
-          cursor: 0,
+          cursor: pageParam,
         });
+
         return res;
       }
     },
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    initialPageParam: 0,
     enabled: typeof id === 'string',
   });
 
   const isLoading = epigramDetailLoading || commentDetailLoading;
   const isError = epigramDetailError || commentDetailError;
+
+  // 페이지 이동후 다시 들어왔을때 더보기로 보여진 댓글 컨텐츠 초기화
+  useEffect(() => {
+    queryClient.resetQueries<any>(['commentDetail']);
+  }, []);
 
   if (!loginState) {
     return (
@@ -99,6 +114,8 @@ export default function DetailPage() {
         data={commentDetailData}
         userId={userData?.id}
         epigramId={Number(commentId)}
+        fetchNextPage={fetchNextPage}
+        hasNextPage={hasNextPage}
         refetch={refetch}
       />
     </div>

--- a/epigram/src/pages/feed/index.tsx
+++ b/epigram/src/pages/feed/index.tsx
@@ -1,6 +1,7 @@
 import Epigram from '@/components/share/Epigram';
 import FixedMenu from '@/components/share/FixedMenu';
 import { fetchNewEpigram } from '@/lib/apis/epigram';
+import { useInfiniteScroll } from '@/lib/hooks/useInfiniteScroll';
 import { EpigramType } from '@/lib/types/type';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
@@ -20,32 +21,13 @@ export default function FeedPage() {
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
       initialPageParam: 0,
     });
-  const [scrollLoading, setScrollLoading] = useState<boolean>(false);
-  const totalCount = data?.pages[0].totalCount;
-  const currentCount =
-    data?.pages?.reduce((acc, page) => acc + page?.list.length, 0) ?? 0;
-  const isMoreButton = currentCount >= totalCount ? false : hasNextPage;
 
-  useEffect(() => {
-    if (hasNextPage) {
-      const handleScroll = () => {
-        if (
-          window.innerHeight + document.documentElement.scrollTop ===
-          document.documentElement.offsetHeight
-        ) {
-          if (!scrollLoading) {
-            setScrollLoading(true);
-            fetchNextPage().finally(() => setScrollLoading(false));
-          }
-        }
-      };
-      window.addEventListener('scroll', handleScroll);
-
-      return () => {
-        window.removeEventListener('scroll', handleScroll);
-      };
-    }
-  }, [hasNextPage, scrollLoading]);
+  // 무함 스크롤
+  const { totalCount, isMoreButton, scrollLoading } = useInfiniteScroll({
+    data,
+    fetchNextPage,
+    hasNextPage,
+  });
 
   if (isLoading) {
     return <div>로딩중...</div>;

--- a/epigram/src/pages/feed/index.tsx
+++ b/epigram/src/pages/feed/index.tsx
@@ -2,19 +2,50 @@ import Epigram from '@/components/share/Epigram';
 import FixedMenu from '@/components/share/FixedMenu';
 import { fetchNewEpigram } from '@/lib/apis/epigram';
 import { EpigramType } from '@/lib/types/type';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 export default function FeedPage() {
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['newEpigramFeed'],
-    queryFn: async () => {
-      const res = await fetchNewEpigram({ limit: 6, cursor: 0 });
-      return res;
-    },
-  });
+  const { data, fetchNextPage, hasNextPage, isLoading, isError } =
+    useInfiniteQuery({
+      queryKey: ['newEpigramFeed'],
+      queryFn: async ({ pageParam = 0 }) => {
+        const res = await fetchNewEpigram({ limit: 6, cursor: pageParam });
+
+        return res;
+      },
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      initialPageParam: 0,
+    });
+  const [scrollLoading, setScrollLoading] = useState<boolean>(false);
+  const totalCount = data?.pages[0].totalCount;
+  const currentCount =
+    data?.pages?.reduce((acc, page) => acc + page?.list.length, 0) ?? 0;
+  const isMoreButton = currentCount >= totalCount ? false : hasNextPage;
+
+  useEffect(() => {
+    if (hasNextPage) {
+      const handleScroll = () => {
+        if (
+          window.innerHeight + document.documentElement.scrollTop ===
+          document.documentElement.offsetHeight
+        ) {
+          if (!scrollLoading) {
+            setScrollLoading(true);
+            fetchNextPage().finally(() => setScrollLoading(false));
+          }
+        }
+      };
+      window.addEventListener('scroll', handleScroll);
+
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+      };
+    }
+  }, [hasNextPage, scrollLoading]);
 
   if (isLoading) {
     return <div>로딩중...</div>;
@@ -25,24 +56,26 @@ export default function FeedPage() {
   }
 
   return (
-    <div className="h-full min-h-screen bg-background py-[120px]">
+    <div className="relative h-full min-h-screen bg-background py-[120px]">
       <h2 className="mx-auto mb-10 w-full max-w-[1200px] text-2xl font-semibold text-black-600">
         피드
       </h2>
       <div
         className={clsx(
           'mx-auto grid w-full max-w-[1200px] gap-x-[30px] gap-y-[40px]',
-          data?.list && data.list.length > 0 && 'grid-cols-2'
+          data?.pages && totalCount > 0 && 'grid-cols-2'
         )}
       >
-        {data?.list && data.list.length > 0 ? (
-          data.list.map((epigram: EpigramType) => {
-            return (
-              <Link href={`/feed/${epigram.id}`} key={epigram.id}>
-                <Epigram data={epigram} height={260} />
-              </Link>
-            );
-          })
+        {data?.pages && totalCount > 0 ? (
+          data?.pages?.flatMap(({ list }) =>
+            list?.map((epigram: EpigramType) => {
+              return (
+                <Link href={`/feed/${epigram.id}`} key={epigram.id}>
+                  <Epigram data={epigram} height={260} />
+                </Link>
+              );
+            })
+          )
         ) : (
           <div className="flex flex-col items-center justify-center gap-2">
             <Image
@@ -57,14 +90,19 @@ export default function FeedPage() {
           </div>
         )}
       </div>
-      {data?.list?.length > 6 && (
-        <div className="mt-[72px] flex justify-center">
-          <Link
-            href="/"
-            className="flex h-[56px] w-full max-w-[238px] items-center justify-center rounded-full border-[1px] border-line-200 text-xl font-medium text-blue-500"
-          >
-            + 에피그램 더보기
-          </Link>
+      {isMoreButton && (
+        <div className="absolute bottom-10 left-[50%] flex translate-x-[-50%] flex-col items-center justify-center gap-1 text-base font-semibold">
+          {/* <span className="text-blue-400">피드 더보기</span> */}
+          {scrollLoading ? (
+            <span className="text-xl text-blue-400">. . .</span>
+          ) : (
+            <Image
+              src="/icons/scroll-icon.svg"
+              width={34}
+              height={34}
+              alt="스크롤 아이콘"
+            />
+          )}
         </div>
       )}
       <FixedMenu />

--- a/epigram/src/pages/feed/index.tsx
+++ b/epigram/src/pages/feed/index.tsx
@@ -9,7 +9,7 @@ import Link from 'next/link';
 
 export default function FeedPage() {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['newEpigram'],
+    queryKey: ['newEpigramFeed'],
     queryFn: async () => {
       const res = await fetchNewEpigram({ limit: 6, cursor: 0 });
       return res;
@@ -57,7 +57,7 @@ export default function FeedPage() {
           </div>
         )}
       </div>
-      {data.list.length > 6 && (
+      {data?.list?.length > 6 && (
         <div className="mt-[72px] flex justify-center">
           <Link
             href="/"

--- a/epigram/src/pages/search/index.tsx
+++ b/epigram/src/pages/search/index.tsx
@@ -1,33 +1,42 @@
 import { fetchNewEpigram } from '@/lib/apis/epigram';
 import { EpigramType } from '@/lib/types/type';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 export default function SearchPage() {
+  const queryClient = useQueryClient();
   const [keyword, setKeyword] = useState<string>(''); // 최종 검색어
   const [inputValue, setInputValue] = useState<string>(''); // input 검색어
   const [recentKeywordList, setRecentKeywordList] = useState<string[]>([]); // 최근 검색어 리스트
   const [isSearch, setIsSearch] = useState<boolean>(); // 검색 여부
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['searchEpigram', keyword],
-    queryFn: async () => {
-      const res = await fetchNewEpigram({
-        limit: 4,
-        cursor: 0,
-        keyword: keyword,
-      });
+  const { data, fetchNextPage, hasNextPage, isLoading, isError } =
+    useInfiniteQuery({
+      queryKey: ['searchEpigram', keyword],
+      queryFn: async ({ pageParam = 0 }) => {
+        const res = await fetchNewEpigram({
+          limit: 4,
+          cursor: pageParam,
+          keyword: keyword,
+        });
 
-      if (res.list.length > 0) {
-        return res;
-      } else {
-        setIsSearch(true);
-        return res;
-      }
-    },
-    enabled: !!keyword,
-  });
+        if (res.list.length > 0) {
+          return res;
+        } else {
+          setIsSearch(true);
+          return res;
+        }
+      },
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      initialPageParam: 0,
+      enabled: !!keyword,
+    });
+  const [scrollLoading, setScrollLoading] = useState<boolean>(false);
+  const totalCount = data?.pages[0].totalCount;
+  const currentCount =
+    data?.pages?.reduce((acc, page) => acc + page?.list.length, 0) ?? 0;
+  const isMoreButton = currentCount >= totalCount ? false : hasNextPage;
 
   // 최근 검색어 추가
   const handleSaveKeyword = (newKeyword: string) => {
@@ -75,6 +84,34 @@ export default function SearchPage() {
     setRecentKeywordList(savedKeywordList);
   }, []);
 
+  // 무한 스크롤
+  useEffect(() => {
+    if (hasNextPage) {
+      const handleScroll = () => {
+        if (
+          window.innerHeight + document.documentElement.scrollTop ===
+          document.documentElement.offsetHeight
+        ) {
+          if (!scrollLoading) {
+            setScrollLoading(true);
+            fetchNextPage().finally(() => setScrollLoading(false));
+          }
+        }
+      };
+
+      window.addEventListener('scroll', handleScroll);
+
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+      };
+    }
+  }, [hasNextPage, scrollLoading]);
+
+  // 이미 검색한 내용 다시 검색했을때 초기화
+  useEffect(() => {
+    queryClient.resetQueries<any>(['searchEpigram']);
+  }, [keyword]);
+
   if (isLoading) {
     return <div>로딩중</div>;
   }
@@ -83,7 +120,7 @@ export default function SearchPage() {
     return <div>에러</div>;
   }
   return (
-    <div className="mx-auto my-[46px] w-full max-w-[640px]">
+    <div className="relative mx-auto my-[46px] w-full max-w-[640px]">
       <form onSubmit={handleSubmit}>
         <div className="mb-10 flex items-center justify-between border-b-4 border-b-black-800 pb-[22px]">
           <input
@@ -138,38 +175,39 @@ export default function SearchPage() {
           </ul>
         </>
       )}
-
-      {data?.list.length > 0
-        ? data.list.map((epigram: EpigramType) => {
-            return (
-              <div
-                key={epigram.id}
-                className="border-b-[1px] border-b-gray-100 p-6"
-              >
-                <Link
-                  href={`/feed/${epigram.id}`}
-                  className="font-point text-xl font-medium text-black-600 hover:font-semibold"
+      {totalCount > 0
+        ? data?.pages?.flatMap(({ list }) =>
+            list?.map((epigram: EpigramType) => {
+              return (
+                <div
+                  key={epigram.id}
+                  className="border-b-[1px] border-b-gray-100 p-6"
                 >
-                  {epigram.content}
-                </Link>
-                <span className="mt-6 block text-xl font-medium text-blue-400">
-                  - {epigram.author} -
-                </span>
-                <ul className="flex flex-wrap items-center justify-end gap-3">
-                  {epigram.tags?.map((tag) => {
-                    return (
-                      <li
-                        key={tag.id}
-                        className="text-xl font-normal text-blue-400"
-                      >
-                        #{tag.name}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            );
-          })
+                  <Link
+                    href={`/feed/${epigram.id}`}
+                    className="font-point text-xl font-medium text-black-600 hover:font-semibold"
+                  >
+                    {epigram.content}
+                  </Link>
+                  <span className="mt-6 block text-xl font-medium text-blue-400">
+                    - {epigram.author} -
+                  </span>
+                  <ul className="flex flex-wrap items-center justify-end gap-3">
+                    {epigram.tags?.map((tag) => {
+                      return (
+                        <li
+                          key={tag.id}
+                          className="text-xl font-normal text-blue-400"
+                        >
+                          #{tag.name}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              );
+            })
+          )
         : isSearch && (
             <div className="flex flex-col items-center justify-center gap-2">
               <Image
@@ -183,6 +221,22 @@ export default function SearchPage() {
               </h3>
             </div>
           )}
+
+      {isMoreButton && (
+        <div className="absolute bottom-10 left-[50%] flex translate-x-[-50%] flex-col items-center justify-center gap-1 text-base font-semibold">
+          {/* <span className="text-blue-400">피드 더보기</span> */}
+          {scrollLoading ? (
+            <span className="text-xl text-blue-400">. . .</span>
+          ) : (
+            <Image
+              src="/icons/scroll-icon.svg"
+              width={34}
+              height={34}
+              alt="스크롤 아이콘"
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/epigram/src/pages/search/index.tsx
+++ b/epigram/src/pages/search/index.tsx
@@ -1,4 +1,5 @@
 import { fetchNewEpigram } from '@/lib/apis/epigram';
+import { useInfiniteScroll } from '@/lib/hooks/useInfiniteScroll';
 import { EpigramType } from '@/lib/types/type';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
@@ -32,11 +33,13 @@ export default function SearchPage() {
       initialPageParam: 0,
       enabled: !!keyword,
     });
-  const [scrollLoading, setScrollLoading] = useState<boolean>(false);
-  const totalCount = data?.pages[0].totalCount;
-  const currentCount =
-    data?.pages?.reduce((acc, page) => acc + page?.list.length, 0) ?? 0;
-  const isMoreButton = currentCount >= totalCount ? false : hasNextPage;
+
+  // 무함 스크롤
+  const { totalCount, isMoreButton, scrollLoading } = useInfiniteScroll({
+    data,
+    fetchNextPage,
+    hasNextPage,
+  });
 
   // 최근 검색어 추가
   const handleSaveKeyword = (newKeyword: string) => {
@@ -83,29 +86,6 @@ export default function SearchPage() {
     setIsSearch(false);
     setRecentKeywordList(savedKeywordList);
   }, []);
-
-  // 무한 스크롤
-  useEffect(() => {
-    if (hasNextPage) {
-      const handleScroll = () => {
-        if (
-          window.innerHeight + document.documentElement.scrollTop ===
-          document.documentElement.offsetHeight
-        ) {
-          if (!scrollLoading) {
-            setScrollLoading(true);
-            fetchNextPage().finally(() => setScrollLoading(false));
-          }
-        }
-      };
-
-      window.addEventListener('scroll', handleScroll);
-
-      return () => {
-        window.removeEventListener('scroll', handleScroll);
-      };
-    }
-  }, [hasNextPage, scrollLoading]);
 
   // 이미 검색한 내용 다시 검색했을때 초기화
   useEffect(() => {


### PR DESCRIPTION
# 작업분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- useInfiniteQuery를 사용하여 더보기&무한 스크롤 기능 구현

# 작업 상세 내용
- 탑버튼 기능 구현

https://github.com/user-attachments/assets/9ad9635c-461f-4100-9e11-d7ae8130c527

- 검색후 피드의 상세 페이지는 로그인후 접근 가능하도록 적용

https://github.com/user-attachments/assets/77384998-1ca2-423c-8311-e1f06bc6e56e

### 더보기 기능
- 최신 에피그램 리스트(메인페이지)
  - 최대 10개 이상이 되면 더보기 버튼 대신 피드 페이지 이동 버튼 노출

https://github.com/user-attachments/assets/c6f17255-a15b-4f44-9d41-3bd6b176d76d

- 최신 댓글 리스트(메인페이지)
  - 최신 댓글을 보여준 후 피드 더보기 버트느 대신 피드 페이지 이동 버튼 노출

https://github.com/user-attachments/assets/5e99339c-c7c9-4308-8d78-770f9b058ecd

- 피드 리스트(마이페이지)
  - 모든 에피그램을 보여준후 접기 버튼 노출

https://github.com/user-attachments/assets/4da53121-dbce-485d-a65f-770aaaf264e3

- 댓글 리스트(마이페이지)
  - 모든 댓글을 보여준후 접기 버튼 노출

https://github.com/user-attachments/assets/627de6ca-4afe-4063-9d05-daa3423c6714

### 무한 스크롤 기능
- 검색 리스트(검색 페이지)

https://github.com/user-attachments/assets/2bc9348a-11d2-41f2-a847-0d6c132f4aac

- 피드 리스트(피드 페이지)

https://github.com/user-attachments/assets/5815b283-bde3-4428-b813-b59f20b2d236

- 댓글 리스트(피드 상세 페이지)

https://github.com/user-attachments/assets/9d88e62d-a017-41b4-8463-fb0c85522954

# 리뷰 요구사항

_집중 리뷰 부분 작성_

# 연관된 이슈 번호
- #37 
